### PR TITLE
Fix Copilot SSL regression and alert/report hardening

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,16 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Verify bundled eBPF object
-        run: test -s bpf/dhi_ssl.bpf.o
+      - name: Install eBPF build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends clang llvm bpftool linux-headers-generic
+
+      - name: Rebuild bundled eBPF object
+        run: |
+          bpftool btf dump file /sys/kernel/btf/vmlinux format c > bpf/vmlinux.h
+          clang -O2 -g -target bpf -I bpf -c bpf/dhi_ssl.bpf.c -o bpf/dhi_ssl.bpf.o
+          test -s bpf/dhi_ssl.bpf.o
 
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}

--- a/bpf/dhi_ssl.bpf.c
+++ b/bpf/dhi_ssl.bpf.c
@@ -109,8 +109,15 @@ static __always_inline int submit_ssl_event(struct ssl_event *scratch, void *buf
     __u32 to_read = len < CAPTURE_CHUNK_SIZE ? len : CAPTURE_CHUNK_SIZE;
     event->data_len = to_read;
 
+    // For large outbound writes, capture from the end of the buffer where prompt/content
+    // payload is commonly located (headers and framing are typically at the front).
+    void *read_ptr = buf;
+    if (len > CAPTURE_CHUNK_SIZE && scratch->direction == SSL_WRITE) {
+        read_ptr = (void *)((char *)buf + (len - CAPTURE_CHUNK_SIZE));
+    }
+
     // Read data from userspace (bounded read)
-    if (bpf_probe_read_user(event->data, to_read, buf) < 0) {
+    if (bpf_probe_read_user(event->data, to_read, read_ptr) < 0) {
         bpf_ringbuf_discard(event, 0);
         return 0;
     }

--- a/src/agentic/mod.rs
+++ b/src/agentic/mod.rs
@@ -270,6 +270,10 @@ impl AgenticRuntime {
         Arc::clone(&self.fingerprinter)
     }
 
+    pub async fn emit_external_alert(&self, alert: Alert) -> Result<()> {
+        self.alerter.send(&alert).await
+    }
+
     pub fn configure_max_budget_usd(&self, max_budget_usd: f64) {
         self.budget_controller.set_global_limit(BudgetLimit {
             daily_usd: max_budget_usd,

--- a/src/ebpf/linux.rs
+++ b/src/ebpf/linux.rs
@@ -72,6 +72,24 @@ struct RawSslEventHeader {
 
 const SSL_EVENT_MAX_DATA_SIZE: usize = 16384;
 
+fn process_looks_like_copilot(pid: u32, comm_lower: &str) -> Option<bool> {
+    if comm_lower.contains("copilot") || comm_lower.contains("mainthread") {
+        return Some(true);
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let exe_path = std::path::PathBuf::from(format!("/proc/{pid}/exe"));
+        if let Ok(target) = std::fs::read_link(exe_path) {
+            let exe = target.to_string_lossy().to_ascii_lowercase();
+            return Some(exe.contains("copilot") || exe.contains("npm-loader"));
+        }
+        return None;
+    }
+    #[allow(unreachable_code)]
+    Some(false)
+}
+
 /// Start the eBPF monitor
 pub async fn start_monitor(runtime: &crate::DhiRuntime) -> Result<()> {
     info!("Starting eBPF monitor on Linux");
@@ -92,6 +110,7 @@ pub async fn start_monitor(runtime: &crate::DhiRuntime) -> Result<()> {
 
     // Start SSL/TLS interception
     tokio::spawn(start_ssl_monitor(
+        runtime.agentic.clone(),
         runtime.agentic.fingerprinter(),
         runtime.stats.clone(),
         protection_level,
@@ -154,6 +173,7 @@ pub async fn start_monitor(runtime: &crate::DhiRuntime) -> Result<()> {
 
 /// Start SSL/TLS traffic monitoring
 async fn start_ssl_monitor(
+    agentic: std::sync::Arc<crate::agentic::AgenticRuntime>,
     fingerprinter: std::sync::Arc<crate::agentic::AgentFingerprinter>,
     runtime_stats: std::sync::Arc<tokio::sync::RwLock<crate::RuntimeStats>>,
     protection_level: crate::ProtectionLevel,
@@ -181,29 +201,72 @@ async fn start_ssl_monitor(
     };
 
     // Start the tracer and attach SSL probes.
-    let attached = match tracer.start(&mut bpf).await {
-        Ok(n) => n,
+    let attach_stats = match tracer.start(&mut bpf).await {
+        Ok(stats) => stats,
         Err(e) => {
             warn!("Failed to start SSL tracer: {}", e);
             return;
         },
     };
-    if attached == 0 {
+    {
+        let mut stats = runtime_stats.write().await;
+        stats.ssl_probe_targets_total = attach_stats.targets_total;
+        stats.ssl_probe_targets_with_attached = attach_stats.targets_with_attached;
+        stats.ssl_probe_attempts_total = attach_stats.attempts_total;
+        stats.ssl_probe_attached_total = attach_stats.attached_total;
+        stats.ssl_probe_failed_total = attach_stats.failed_total;
+    }
+    info!(
+        "SSL probe attach summary: targets={} attached_targets={} attempts={} attached={} failed={}",
+        attach_stats.targets_total,
+        attach_stats.targets_with_attached,
+        attach_stats.attempts_total,
+        attach_stats.attached_total,
+        attach_stats.failed_total
+    );
+    if attach_stats.attached_total == 0 {
         warn!("No SSL uprobes were attached. SSL tracing disabled.");
         return;
     }
 
     // Process analyzed SSL events.
+    let runtime_stats_for_outcome = runtime_stats.clone();
     tokio::spawn(async move {
         while let Some(event) = rx.recv().await {
             match process_ssl_event_with_outcome(&event, &monitor).await {
                 Ok(outcome) => {
                     if outcome.risk_score > 0 {
-                        let mut stats = runtime_stats.write().await;
+                        let mut stats = runtime_stats_for_outcome.write().await;
                         stats.total_alerts = stats.total_alerts.saturating_add(1);
+                        let severity = if outcome.risk_score >= 90 {
+                            crate::agentic::AlertSeverity::Critical
+                        } else if outcome.risk_score >= 70 {
+                            crate::agentic::AlertSeverity::Warning
+                        } else {
+                            crate::agentic::AlertSeverity::Info
+                        };
+                        let mut alert = crate::agentic::Alert::new(
+                            severity,
+                            "SSL traffic risk detected",
+                            &format!(
+                                "SSL risk detected for process {} (pid={})",
+                                event.comm, event.pid
+                            ),
+                        )
+                        .with_event_type("ssl_risk_detected")
+                        .with_process(Some(&event.comm), Some(event.pid))
+                        .with_risk_score(outcome.risk_score);
+                        if outcome.blocked {
+                            alert = alert.with_action("BLOCKED");
+                        } else {
+                            alert = alert.with_action("ALERTED");
+                        }
+                        if let Err(e) = agentic.emit_external_alert(alert).await {
+                            warn!("Failed to persist SSL alert to alert pipeline: {}", e);
+                        }
                     }
                     if outcome.blocked {
-                        let mut stats = runtime_stats.write().await;
+                        let mut stats = runtime_stats_for_outcome.write().await;
                         stats.total_blocks = stats.total_blocks.saturating_add(1);
                     }
                     if outcome.blocked {
@@ -238,6 +301,7 @@ async fn start_ssl_monitor(
     };
 
     info!("SSL/TLS interception active - monitoring encrypted traffic");
+    let runtime_stats_for_ring = runtime_stats.clone();
 
     loop {
         if let Some(event_data) = ssl_ring_buf.next() {
@@ -275,18 +339,44 @@ async fn start_ssl_monitor(
                 "SSL raw event received: pid={} tid={} dir={} data_len={}",
                 raw.pid, raw.tid, raw.direction, raw.data_len
             );
+            {
+                let mut stats = runtime_stats_for_ring.write().await;
+                stats.ssl_events_total = stats.ssl_events_total.saturating_add(1);
+            }
             let comm_str = std::str::from_utf8(&raw.comm)
                 .unwrap_or("")
                 .trim_end_matches('\0')
                 .to_ascii_lowercase();
-            if comm_str.contains("copilot") || comm_str.contains("mainthread") {
-                info!(
-                    "[COPILOT RAW EVENT] pid={} tid={} dir={} data_len={}",
-                    raw.pid, raw.tid, raw.direction, raw.data_len
-                );
+            let is_copilot_like = process_looks_like_copilot(raw.pid, &comm_str);
+            if matches!(is_copilot_like, Some(true)) {
+                {
+                    let mut stats = runtime_stats_for_ring.write().await;
+                    stats.ssl_events_copilot_total =
+                        stats.ssl_events_copilot_total.saturating_add(1);
+                }
+                if !comm_str.contains("copilot") && !comm_str.contains("mainthread") {
+                    let mut stats = runtime_stats_for_ring.write().await;
+                    stats.ssl_events_copilot_by_exe_total =
+                        stats.ssl_events_copilot_by_exe_total.saturating_add(1);
+                }
+                if comm_str.contains("copilot") || comm_str.contains("mainthread") {
+                    info!(
+                        "[COPILOT RAW EVENT] pid={} tid={} dir={} data_len={}",
+                        raw.pid, raw.tid, raw.direction, raw.data_len
+                    );
+                }
+            } else if is_copilot_like.is_none() {
+                let mut stats = runtime_stats_for_ring.write().await;
+                stats.ssl_events_exe_resolve_failures =
+                    stats.ssl_events_exe_resolve_failures.saturating_add(1);
             }
 
             if let Err(e) = tracer.monitor().process_raw_event(&raw).await {
+                {
+                    let mut stats = runtime_stats_for_ring.write().await;
+                    stats.ssl_events_parse_errors =
+                        stats.ssl_events_parse_errors.saturating_add(1);
+                }
                 debug!("Failed to process raw SSL event: {}", e);
             }
         } else {

--- a/src/ebpf/linux.rs
+++ b/src/ebpf/linux.rs
@@ -16,7 +16,8 @@ use super::{EbpfEventType, FileEvent, NetworkEvent};
 /// eBPF program candidates (ordered by preference).
 /// Current release artifacts install `dhi_ssl.bpf.o`, while legacy installs may still use
 /// `dhi.bpf.o`.
-const BPF_PROGRAM_PATH_CANDIDATES: [&str; 2] = ["/usr/share/dhi/dhi_ssl.bpf.o", "/usr/share/dhi/dhi.bpf.o"];
+const BPF_PROGRAM_PATH_CANDIDATES: [&str; 2] =
+    ["/usr/share/dhi/dhi_ssl.bpf.o", "/usr/share/dhi/dhi.bpf.o"];
 
 fn resolve_bpf_program_path_from_candidates<'a>(candidates: &'a [&'a str]) -> Option<&'a str> {
     candidates
@@ -374,8 +375,7 @@ async fn start_ssl_monitor(
             if let Err(e) = tracer.monitor().process_raw_event(&raw).await {
                 {
                     let mut stats = runtime_stats_for_ring.write().await;
-                    stats.ssl_events_parse_errors =
-                        stats.ssl_events_parse_errors.saturating_add(1);
+                    stats.ssl_events_parse_errors = stats.ssl_events_parse_errors.saturating_add(1);
                 }
                 debug!("Failed to process raw SSL event: {}", e);
             }

--- a/src/ebpf/ssl_hook.rs
+++ b/src/ebpf/ssl_hook.rs
@@ -494,7 +494,9 @@ impl SslMonitor {
             let connections = self.connections.read().await;
             if let Some(conn) = connections.get(&event.ssl_ptr) {
                 let primary = match event.direction {
-                    SslDirection::Write if !conn.write_buffer.is_empty() => conn.write_buffer.clone(),
+                    SslDirection::Write if !conn.write_buffer.is_empty() => {
+                        conn.write_buffer.clone()
+                    },
                     SslDirection::Read if !conn.read_buffer.is_empty() => conn.read_buffer.clone(),
                     _ => event.data.clone(),
                 };
@@ -534,7 +536,9 @@ impl SslMonitor {
         if !result.has_secrets {
             let compact = text.replace('\0', "");
             let compact_combined = combined_text.replace('\0', "");
-            if AWS_KEY_FALLBACK_RE.is_match(&compact) || AWS_KEY_FALLBACK_RE.is_match(&compact_combined) {
+            if AWS_KEY_FALLBACK_RE.is_match(&compact)
+                || AWS_KEY_FALLBACK_RE.is_match(&compact_combined)
+            {
                 result.has_secrets = true;
                 result.secrets_detected = vec!["aws_access_key".to_string()];
                 result.risk_score = result.risk_score.max(95);
@@ -700,8 +704,12 @@ impl SslTracer {
                 lib.path.display()
             );
             let target_stats = self.attach_probes(bpf, lib).await?;
-            stats.attempts_total = stats.attempts_total.saturating_add(target_stats.attempts_total);
-            stats.attached_total = stats.attached_total.saturating_add(target_stats.attached_total);
+            stats.attempts_total = stats
+                .attempts_total
+                .saturating_add(target_stats.attempts_total);
+            stats.attached_total = stats
+                .attached_total
+                .saturating_add(target_stats.attached_total);
             stats.failed_total = stats.failed_total.saturating_add(target_stats.failed_total);
             if target_stats.attached_total > 0 {
                 stats.targets_with_attached = stats.targets_with_attached.saturating_add(1);

--- a/src/ebpf/ssl_hook.rs
+++ b/src/ebpf/ssl_hook.rs
@@ -8,7 +8,9 @@
 use anyhow::Result;
 use aya::programs::{ProgramError, UProbe};
 use aya::Bpf;
+use lazy_static::lazy_static;
 use object::{Object, ObjectSection, ObjectSymbol};
+use regex::Regex;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -270,9 +272,11 @@ fn discover_runtime_ssl_targets() -> Vec<PathBuf> {
                 let Ok(exe_path) = std::fs::read_link(exe_link) else {
                     continue;
                 };
+                let mut is_deleted_exe = false;
                 let mut normalized = exe_path.clone();
                 if let Some(exe_str) = exe_path.to_str() {
                     if let Some(stripped) = exe_str.strip_suffix(" (deleted)") {
+                        is_deleted_exe = true;
                         normalized = PathBuf::from(stripped);
                     }
                 }
@@ -281,6 +285,14 @@ fn discover_runtime_ssl_targets() -> Vec<PathBuf> {
                     continue;
                 };
                 if file_name == "copilot" {
+                    // Always include the live procfs executable path so we can bind to the
+                    // currently running inode even when the on-disk path is inaccessible.
+                    add_target(entry.path().join("exe"));
+                    // If the executable was replaced on disk, `/proc/<pid>/exe` still points
+                    // to the running inode. Attach to that live path as well.
+                    if is_deleted_exe {
+                        add_target(entry.path().join("exe"));
+                    }
                     add_target(normalized);
                 }
             }
@@ -355,6 +367,21 @@ pub struct SslConnectionInfo {
 }
 
 const ANALYSIS_BUFFER_LIMIT: usize = 4096;
+
+lazy_static! {
+    static ref AWS_KEY_FALLBACK_RE: Regex = match Regex::new(r"AKIA[0-9A-Z]{16}") {
+        Ok(re) => re,
+        Err(err) => panic!("invalid AWS key fallback regex: {err}"),
+    };
+    static ref SSN_FALLBACK_RE: Regex = match Regex::new(r"\b\d{3}-?\d{2}-?\d{4}\b") {
+        Ok(re) => re,
+        Err(err) => panic!("invalid SSN fallback regex: {err}"),
+    };
+    static ref CARD_FALLBACK_RE: Regex = match Regex::new(r"\b(?:\d[ -]*?){13,19}\b") {
+        Ok(re) => re,
+        Err(err) => panic!("invalid card fallback regex: {err}"),
+    };
+}
 
 impl SslMonitor {
     /// Create a new SSL monitor
@@ -463,29 +490,38 @@ impl SslMonitor {
 
     /// Analyze SSL event for security issues
     pub async fn analyze_event(&self, event: &SslEvent) -> SslAnalysisResult {
-        let analysis_bytes = {
+        let (analysis_bytes, combined_bytes) = {
             let connections = self.connections.read().await;
             if let Some(conn) = connections.get(&event.ssl_ptr) {
-                match event.direction {
-                    SslDirection::Write if !conn.write_buffer.is_empty() => {
-                        conn.write_buffer.clone()
-                    },
+                let primary = match event.direction {
+                    SslDirection::Write if !conn.write_buffer.is_empty() => conn.write_buffer.clone(),
                     SslDirection::Read if !conn.read_buffer.is_empty() => conn.read_buffer.clone(),
                     _ => event.data.clone(),
+                };
+                let mut combined = conn.write_buffer.clone();
+                combined.extend_from_slice(&conn.read_buffer);
+                if combined.len() > ANALYSIS_BUFFER_LIMIT * 2 {
+                    let excess = combined.len() - (ANALYSIS_BUFFER_LIMIT * 2);
+                    combined.drain(0..excess);
                 }
+                (primary, combined)
             } else {
-                event.data.clone()
+                (event.data.clone(), event.data.clone())
             }
         };
 
         // SSL payloads can mix text and binary framing (e.g., HTTP/2).
         // Use lossy UTF-8 so detectors can still match ASCII patterns.
         let text = String::from_utf8_lossy(&analysis_bytes).to_string();
+        let combined_text = String::from_utf8_lossy(&combined_bytes).to_string();
 
         let mut result = SslAnalysisResult::default();
 
         // Detect secrets
-        let secrets = self.secrets_detector.scan(&text, "ssl");
+        let mut secrets = self.secrets_detector.scan(&text, "ssl");
+        if !secrets.secrets_found && combined_text != text {
+            secrets = self.secrets_detector.scan(&combined_text, "ssl");
+        }
         if secrets.secrets_found {
             result.secrets_detected = secrets
                 .secrets
@@ -495,13 +531,45 @@ impl SslMonitor {
             result.has_secrets = true;
             result.risk_score = result.risk_score.max(95);
         }
+        if !result.has_secrets {
+            let compact = text.replace('\0', "");
+            let compact_combined = combined_text.replace('\0', "");
+            if AWS_KEY_FALLBACK_RE.is_match(&compact) || AWS_KEY_FALLBACK_RE.is_match(&compact_combined) {
+                result.has_secrets = true;
+                result.secrets_detected = vec!["aws_access_key".to_string()];
+                result.risk_score = result.risk_score.max(95);
+            }
+        }
 
         // Detect PII
-        let pii = self.pii_detector.scan(&text, "ssl");
+        let mut pii = self.pii_detector.scan(&text, "ssl");
+        if !pii.pii_found && combined_text != text {
+            pii = self.pii_detector.scan(&combined_text, "ssl");
+        }
         if pii.pii_found {
             result.pii_detected = pii.pii_types.iter().map(|p| p.pii_type.clone()).collect();
             result.has_pii = true;
             result.risk_score = result.risk_score.max(70);
+        }
+        if !result.has_pii {
+            let compact = text.replace('\0', "");
+            let compact_combined = combined_text.replace('\0', "");
+            let has_ssn =
+                SSN_FALLBACK_RE.is_match(&compact) || SSN_FALLBACK_RE.is_match(&compact_combined);
+            let has_card =
+                CARD_FALLBACK_RE.is_match(&compact) || CARD_FALLBACK_RE.is_match(&compact_combined);
+            if has_ssn || has_card {
+                result.has_pii = true;
+                let mut pii_types = Vec::new();
+                if has_ssn {
+                    pii_types.push("ssn".to_string());
+                }
+                if has_card {
+                    pii_types.push("credit_card".to_string());
+                }
+                result.pii_detected = pii_types;
+                result.risk_score = result.risk_score.max(70);
+            }
         }
 
         // Copilot traffic is often fragmented across request/response frames.
@@ -578,6 +646,15 @@ pub struct SslProcessOutcome {
     pub blocked: bool,
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SslAttachStats {
+    pub targets_total: u64,
+    pub targets_with_attached: u64,
+    pub attempts_total: u64,
+    pub attached_total: u64,
+    pub failed_total: u64,
+}
+
 /// eBPF SSL Tracer - attaches uprobes to SSL libraries
 #[cfg(target_os = "linux")]
 pub struct SslTracer {
@@ -604,114 +681,156 @@ impl SslTracer {
     }
 
     /// Start tracing SSL functions
-    pub async fn start(&self, bpf: &mut Bpf) -> Result<usize> {
+    pub async fn start(&self, bpf: &mut Bpf) -> Result<SslAttachStats> {
         if self.libraries.is_empty() {
             warn!("No SSL libraries found - SSL tracing disabled");
-            return Ok(0);
+            return Ok(SslAttachStats::default());
         }
 
         info!("Starting SSL/TLS traffic interception via eBPF uprobes");
 
-        let mut attached = 0usize;
+        let mut stats = SslAttachStats {
+            targets_total: self.libraries.len() as u64,
+            ..SslAttachStats::default()
+        };
         for lib in &self.libraries {
             info!(
                 "Attaching probes to {:?} at {}",
                 lib.library,
                 lib.path.display()
             );
-            attached += self.attach_probes(bpf, lib).await?;
+            let target_stats = self.attach_probes(bpf, lib).await?;
+            stats.attempts_total = stats.attempts_total.saturating_add(target_stats.attempts_total);
+            stats.attached_total = stats.attached_total.saturating_add(target_stats.attached_total);
+            stats.failed_total = stats.failed_total.saturating_add(target_stats.failed_total);
+            if target_stats.attached_total > 0 {
+                stats.targets_with_attached = stats.targets_with_attached.saturating_add(1);
+            }
         }
 
-        Ok(attached)
+        Ok(stats)
     }
 
     /// Attach uprobes to a specific library
-    async fn attach_probes(&self, bpf: &mut Bpf, lib: &LibraryProbe) -> Result<usize> {
-        let mut attached = 0usize;
+    async fn attach_probes(&self, bpf: &mut Bpf, lib: &LibraryProbe) -> Result<SslAttachStats> {
+        let mut stats = SslAttachStats::default();
         let lib_path = &lib.path;
 
         match lib.library {
             SslLibrary::OpenSSL | SslLibrary::BoringSSL | SslLibrary::LibreSSL => {
-                attached += attach_uprobe_program(
-                    bpf,
-                    "uprobe_ssl_write",
-                    Some(lib.write_symbol),
-                    0,
-                    lib_path,
-                )?;
-                attached += attach_uprobe_program(
-                    bpf,
-                    "uprobe_ssl_read_entry",
-                    Some(lib.read_symbol),
-                    0,
-                    lib_path,
-                )?;
-                attached += attach_uprobe_program(
-                    bpf,
-                    "uretprobe_ssl_read",
-                    Some(lib.read_symbol),
-                    0,
-                    lib_path,
-                )?;
+                accumulate_attach_stats(
+                    &mut stats,
+                    attach_uprobe_program(
+                        bpf,
+                        "uprobe_ssl_write",
+                        Some(lib.write_symbol),
+                        0,
+                        lib_path,
+                    )?,
+                );
+                accumulate_attach_stats(
+                    &mut stats,
+                    attach_uprobe_program(
+                        bpf,
+                        "uprobe_ssl_read_entry",
+                        Some(lib.read_symbol),
+                        0,
+                        lib_path,
+                    )?,
+                );
+                accumulate_attach_stats(
+                    &mut stats,
+                    attach_uprobe_program(
+                        bpf,
+                        "uretprobe_ssl_read",
+                        Some(lib.read_symbol),
+                        0,
+                        lib_path,
+                    )?,
+                );
 
                 if let Some(write_ex) = lib.write_ex_symbol {
-                    attached += attach_uprobe_program(
-                        bpf,
-                        "uprobe_ssl_write_ex",
-                        Some(write_ex),
-                        0,
-                        lib_path,
-                    )?;
+                    accumulate_attach_stats(
+                        &mut stats,
+                        attach_uprobe_program(
+                            bpf,
+                            "uprobe_ssl_write_ex",
+                            Some(write_ex),
+                            0,
+                            lib_path,
+                        )?,
+                    );
                 }
                 if let Some(read_ex) = lib.read_ex_symbol {
-                    attached += attach_uprobe_program(
-                        bpf,
-                        "uprobe_ssl_read_ex_entry",
-                        Some(read_ex),
-                        0,
-                        lib_path,
-                    )?;
-                    attached += attach_uprobe_program(
-                        bpf,
-                        "uretprobe_ssl_read_ex",
-                        Some(read_ex),
-                        0,
-                        lib_path,
-                    )?;
+                    accumulate_attach_stats(
+                        &mut stats,
+                        attach_uprobe_program(
+                            bpf,
+                            "uprobe_ssl_read_ex_entry",
+                            Some(read_ex),
+                            0,
+                            lib_path,
+                        )?,
+                    );
+                    accumulate_attach_stats(
+                        &mut stats,
+                        attach_uprobe_program(
+                            bpf,
+                            "uretprobe_ssl_read_ex",
+                            Some(read_ex),
+                            0,
+                            lib_path,
+                        )?,
+                    );
                 }
             },
             SslLibrary::GnuTLS => {
-                attached += attach_uprobe_program(
-                    bpf,
-                    "uprobe_gnutls_send",
-                    Some("gnutls_record_send"),
-                    0,
-                    lib_path,
-                )?;
-                attached += attach_uprobe_program(
-                    bpf,
-                    "uprobe_gnutls_recv_entry",
-                    Some("gnutls_record_recv"),
-                    0,
-                    lib_path,
-                )?;
-                attached += attach_uprobe_program(
-                    bpf,
-                    "uretprobe_gnutls_recv",
-                    Some("gnutls_record_recv"),
-                    0,
-                    lib_path,
-                )?;
+                accumulate_attach_stats(
+                    &mut stats,
+                    attach_uprobe_program(
+                        bpf,
+                        "uprobe_gnutls_send",
+                        Some("gnutls_record_send"),
+                        0,
+                        lib_path,
+                    )?,
+                );
+                accumulate_attach_stats(
+                    &mut stats,
+                    attach_uprobe_program(
+                        bpf,
+                        "uprobe_gnutls_recv_entry",
+                        Some("gnutls_record_recv"),
+                        0,
+                        lib_path,
+                    )?,
+                );
+                accumulate_attach_stats(
+                    &mut stats,
+                    attach_uprobe_program(
+                        bpf,
+                        "uretprobe_gnutls_recv",
+                        Some("gnutls_record_recv"),
+                        0,
+                        lib_path,
+                    )?,
+                );
             },
         }
 
-        Ok(attached)
+        Ok(stats)
     }
 
     /// Get the monitor for analysis
     pub fn monitor(&self) -> Arc<SslMonitor> {
         Arc::clone(&self.monitor)
     }
+}
+
+fn accumulate_attach_stats(total: &mut SslAttachStats, delta: SslAttachStats) {
+    total.attempts_total = total.attempts_total.saturating_add(delta.attempts_total);
+    total.attached_total = total.attached_total.saturating_add(delta.attached_total);
+    total.failed_total = total.failed_total.saturating_add(delta.failed_total);
 }
 
 #[cfg(target_os = "linux")]
@@ -721,18 +840,21 @@ fn attach_uprobe_program(
     symbol: Option<&str>,
     offset: u64,
     target: &std::path::Path,
-) -> Result<usize> {
+) -> Result<SslAttachStats> {
+    let mut stats = SslAttachStats::default();
     let Some(program) = bpf.program_mut(program_name) else {
         debug!("BPF program {} not found; skipping", program_name);
-        return Ok(0);
+        return Ok(stats);
     };
 
+    stats.attempts_total = 1;
     let uprobe: &mut UProbe = program.try_into()?;
     match uprobe.load() {
         Ok(()) | Err(ProgramError::AlreadyLoaded) => {},
         Err(e) => {
             warn!("Failed to load uprobe program {}: {}", program_name, e);
-            return Ok(0);
+            stats.failed_total = 1;
+            return Ok(stats);
         },
     }
 
@@ -744,9 +866,10 @@ fn attach_uprobe_program(
                 target.display(),
                 symbol.unwrap_or("<offset>")
             );
-            Ok(1)
+            stats.attached_total = 1;
+            Ok(stats)
         },
-        Err(ProgramError::AlreadyAttached) => Ok(0),
+        Err(ProgramError::AlreadyAttached) => Ok(stats),
         Err(e) => {
             // Some binaries (notably self-contained runtimes) may fail symbol-name
             // resolution through perf_event APIs even when symbols exist. Try
@@ -763,9 +886,10 @@ fn attach_uprobe_program(
                                     fallback_offset,
                                     sym
                                 );
-                                return Ok(1);
+                                stats.attached_total = 1;
+                                return Ok(stats);
                             },
-                            Err(ProgramError::AlreadyAttached) => return Ok(0),
+                            Err(ProgramError::AlreadyAttached) => return Ok(stats),
                             Err(e2) => {
                                 warn!(
                                     "Fallback attach failed for {} on {} (symbol {} offset 0x{:x}): {}",
@@ -788,7 +912,8 @@ fn attach_uprobe_program(
                 symbol.unwrap_or("<offset>"),
                 e
             );
-            Ok(0)
+            stats.failed_total = 1;
+            Ok(stats)
         },
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,16 @@ pub struct RuntimeStats {
     pub total_events: u64,
     pub total_alerts: u64,
     pub total_blocks: u64,
+    pub ssl_probe_targets_total: u64,
+    pub ssl_probe_targets_with_attached: u64,
+    pub ssl_probe_attempts_total: u64,
+    pub ssl_probe_attached_total: u64,
+    pub ssl_probe_failed_total: u64,
+    pub ssl_events_total: u64,
+    pub ssl_events_copilot_total: u64,
+    pub ssl_events_copilot_by_exe_total: u64,
+    pub ssl_events_exe_resolve_failures: u64,
+    pub ssl_events_parse_errors: u64,
     pub events_per_second: f64,
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -133,12 +133,35 @@ async fn route_request(
                 .get();
             let alerts = stats.total_alerts;
             let blocked = stats.total_blocks;
+            let ssl_probe_targets_total = stats.ssl_probe_targets_total;
+            let ssl_probe_targets_with_attached = stats.ssl_probe_targets_with_attached;
+            let ssl_probe_attempts_total = stats.ssl_probe_attempts_total;
+            let ssl_probe_attached_total = stats.ssl_probe_attached_total;
+            let ssl_probe_failed_total = stats.ssl_probe_failed_total;
+            let ssl_events = stats.ssl_events_total;
+            let ssl_events_copilot = stats.ssl_events_copilot_total;
+            let ssl_events_copilot_by_exe = stats.ssl_events_copilot_by_exe_total;
+            let ssl_events_exe_resolve_failures = stats.ssl_events_exe_resolve_failures;
+            let ssl_events_parse_errors = stats.ssl_events_parse_errors;
             (
                 "200 OK",
                 "application/json",
                 format!(
-                    r#"{{"llm_calls":{},"tool_calls":{},"alerts":{},"blocked":{}}}"#,
-                    llm_calls, tool_calls, alerts, blocked
+                    r#"{{"llm_calls":{},"tool_calls":{},"alerts":{},"blocked":{},"ssl_probe_targets_total":{},"ssl_probe_targets_with_attached":{},"ssl_probe_attempts_total":{},"ssl_probe_attached_total":{},"ssl_probe_failed_total":{},"ssl_events":{},"ssl_events_copilot":{},"ssl_events_copilot_by_exe":{},"ssl_events_exe_resolve_failures":{},"ssl_events_parse_errors":{}}}"#,
+                    llm_calls,
+                    tool_calls,
+                    alerts,
+                    blocked,
+                    ssl_probe_targets_total,
+                    ssl_probe_targets_with_attached,
+                    ssl_probe_attempts_total,
+                    ssl_probe_attached_total,
+                    ssl_probe_failed_total,
+                    ssl_events,
+                    ssl_events_copilot,
+                    ssl_events_copilot_by_exe,
+                    ssl_events_exe_resolve_failures,
+                    ssl_events_parse_errors
                 ),
             )
         },


### PR DESCRIPTION
## Summary

This PR fixes the Copilot SSL capture regression and hardens runtime observability and release reliability.

- Restores Copilot SSL capture reliability by including live runtime targets from `/proc/<pid>/exe`.
- Routes SSL risk outcomes into the existing alert pipeline so `alerts.log` is populated.
- Exposes richer probe and event telemetry in `/api/stats` for diagnostics.
- Rebuilds bundled eBPF object in the release workflow to avoid stale artifact drift.
- Fixes clippy `expect_used` lint in fallback regex initialization.

## What changed

- `src/ebpf/ssl_hook.rs`
  - Improved runtime target discovery for Copilot processes.
  - Added clippy-compliant regex initialization for fallback detectors.

- `src/ebpf/linux.rs`
  - Added probe attach/event counters and Copilot-specific telemetry updates.
  - Emits SSL detection outcomes through the agentic alerting pipeline.

- `src/agentic/mod.rs`
  - Added `emit_external_alert(...)` to persist external runtime alerts.

- `src/lib.rs`, `src/server.rs`
  - Expanded runtime stats model and `/api/stats` response fields.

- `.github/workflows/release.yml`
  - Rebuilds `bpf/dhi_ssl.bpf.o` during release packaging.

- `bpf/dhi_ssl.bpf.c`
  - Payload-capture adjustment for large outbound writes.

## Validation

- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings -D clippy::expect_used`
- `bash scripts/copilot-cli-e2e.sh --mode alert`
- `bash scripts/reporting-e2e.sh`

## Runtime verification

- Alerts present in: `/var/log/dhi/alerts.log`
- Report generated at: `/var/log/dhi/reports/daily-security-report.html`
